### PR TITLE
Allow OutageException creation w/o params

### DIFF
--- a/lib/breakers/outage_exception.rb
+++ b/lib/breakers/outage_exception.rb
@@ -7,13 +7,21 @@ module Breakers
     attr_reader :outage
     attr_reader :service
 
-    def initialize(outage, service)
+    def initialize(outage = nil, service = nil)
       @outage = outage
       @service = service
     end
 
+    def service_name
+      @service.try(:name) ? @service.name : 'unknown_service'
+    end
+
+    def outage_start_time
+      @outage.try(:start_time) ? @outage.start_time : nil
+    end
+
     def message
-      "Outage detected on #{@service.name} beginning at #{@outage.start_time.to_i}"
+      "Outage detected on #{service_name} beginning at #{outage_start_time.to_i}"
     end
   end
 end


### PR DESCRIPTION
Most exceptions don't require parameters to be initialized or to perform basic functionality, like invoking their `message` method. The fact that `Breakers::OutageException` did seems like a bug to me. This allows it to be initialized with no arguments, which facilitates testing. But when invoked with the two arguments that the gem does use, it continues to behave as before.