### PR TITLE
Spread parameters to Redis#mget

### DIFF
--- a/lib/breakers/service.rb
+++ b/lib/breakers/service.rb
@@ -161,7 +161,7 @@ module Breakers
         end
         start_time += sample_minutes * 60
       end
-      Breakers.client.redis_connection.mget(keys).each_with_index.map do |value, idx|
+      Breakers.client.redis_connection.mget(*keys).each_with_index.map do |value, idx|
         { count: value.to_i, time: times[idx] }
       end
     end


### PR DESCRIPTION
mock_redis did not support passing an array until very recently: https://github.com/brigade/mock_redis/pull/147

That PR has not yet been included in a release on rubygems.org, so instead I've altered the call to `mget` to use spread parameters.