### PR TITLE
Add min_errors logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ the block should return true if the service applies to it.
 Each service can be further configured with the following:
 
 * `seconds_before_retry` - The number of seconds to wait before sending a new request when an outage is reported. Every N seconds, a new request will be sent, and if it succeeds the outage will be ended. Defaults to 60.
+* `min_errors` - At least this many errors need to be observed in the `observe_period_minutes` before an outage will be reported. Defaults to 1.
 * `error_threshold` - The percentage of errors over which an outage will be reported. Defaults to 50.
 * `data_retention_seconds` - The number of seconds for which data will be stored in Redis for successful and unsuccessful request counts. See below for information on the structure of data within Redis. Defaults to 30 days.
+* `success_sample_per` - Record every Nth success by incrementing by N. e.g. Specifying 5 will increment the success count by 5, 20% (1/5) of the time. Helps to reduce write traffic to Redis. Defaults to 1 (no sampling).
 
 ### Client
 


### PR DESCRIPTION
This adds a `min_errors` config option which ensures that at least some minimum number of errors occurs in a two minute period in order for an outage to be recorded. This helps prevent false positives in case there are very few successes also recorded during that time period.

I also made sure to update the readme with docs for both the `min_errors` and `success_sample_per` options.