### PR TITLE
Config option to throttle redis check for the latest outage

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Each service can be further configured with the following:
 * `error_threshold` - The percentage of errors over which an outage will be reported. Defaults to 50.
 * `data_retention_seconds` - The number of seconds for which data will be stored in Redis for successful and unsuccessful request counts. See below for information on the structure of data within Redis. Defaults to 30 days.
 * `success_sample_per` - Record every Nth success by incrementing by N. e.g. Specifying 5 will increment the success count by 5, 20% (1/5) of the time. Helps to reduce write traffic to Redis. Defaults to 1 (no sampling).
-* `outage_check_throttle_seconds` - Check redis for a recorded outage at most once per this time period. Helps to reduce read traffic to Redis. Defaults to 0 (no throttling).
+* `seconds_between_outage_checks` - Check redis for a recorded outage at most once per this time period. Helps to reduce read traffic to Redis. Defaults to 0.
 
 ### Client
 

--- a/lib/breakers/service.rb
+++ b/lib/breakers/service.rb
@@ -9,7 +9,7 @@ module Breakers
       error_threshold: 50,
       data_retention_seconds: 60 * 60 * 24 * 30,
       success_sample_per: 1,
-      outage_check_throttle_seconds: 0
+      seconds_between_outage_checks: 0
     }.freeze
 
     # Create a new service
@@ -95,9 +95,9 @@ module Breakers
     end
 
     # Return the most recent outage on the service, throttled to reference
-    # redis at most once every `outage_check_throttle_seconds`
+    # redis at most once every `seconds_between_outage_checks`
     def latest_outage
-      throttle = @configuration[:outage_check_throttle_seconds]
+      throttle = @configuration[:seconds_between_outage_checks]
       if !@latest_outage_fetched.nil? && @latest_outage_fetched > Time.now - throttle
         @latest_outage
       else

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -559,8 +559,6 @@ describe 'integration suite' do
       Timecop.freeze(now - 30)
       stub_request(:get, 'va.gov').to_return(status: 200, body: 'abcdef')
       40.times { connection.get '/' }
-
-      Timecop.freeze(now)
     end
 
     it 'does not record an outage on a single failure' do
@@ -686,7 +684,7 @@ describe 'integration suite' do
         request_matcher: proc { |request_env| request_env.url.host =~ /.*va.gov/ },
         seconds_before_retry: 60,
         error_threshold: 50,
-        outage_check_throttle_seconds: 10
+        seconds_between_outage_checks: 10
       )
     end
 


### PR DESCRIPTION
By specifying the `seconds_between_outage_checks` option, you can limit the number of times redis is consulted for the latest recorded outage to at most once per that many seconds. This should help reduce redis throughput.