### PR TITLE
Bump version is gemspec

### DIFF
--- a/breakers.gemspec
+++ b/breakers.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'breakers'
-  spec.version       = '0.2.7'
+  spec.version       = '1.0.0'
   spec.authors       = ['Aubrey Holland']
   spec.email         = ['aubrey@adhocteam.us']
 


### PR DESCRIPTION
`version.rb` is not used in the gem spec, so we need to bump in both places. This version bump goes along with #8 