### PR TITLE
Faraday 0.12

### DIFF
--- a/breakers.gemspec
+++ b/breakers.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'breakers'
-  spec.version       = '1.0.0'
+  spec.version       = '1.0.1'
   spec.authors       = ['Aubrey Holland']
   spec.email         = ['aubrey@adhocteam.us']
 


### PR DESCRIPTION
Breakers hadn't really had a reason to reject versions of the `faraday` dependency >= 0.12. I just put that in there because that's all we had tested it with.

At this point, sbn is ready to upgrade that gem and breakers is the only thing holding it back.

Let's remove the limitation here in this gem and trust the Audience folks to do proper testing when the time comes they want to upgrade `faraday`.