### PR TITLE
v1.0.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '27 2 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      # If you wish to specify custom queries, you can do so here or in a config file.
+      # By default, queries listed here will override any specified in a config file.
+      # Prefix the list here with "+" to use these queries and those in the config file.
+      # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+<!-- markdownlint-disable MD013 -->
+<!-- omit in toc -->
+# Contributing to breakers
+
+First off, thanks for taking the time to contribute! :heart:
+
+All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us project owners and smooth out the experience for all involved. The team looks forward to your contributions. :tada:
+
+<!-- omit in toc -->
+## Table of Contents
+
+- [I Have a Question](#i-have-a-question)
+- [I Want To Contribute](#i-want-to-contribute)
+- [Reporting Bugs](#reporting-bugs)
+- [Suggesting Enhancements](#suggesting-enhancements)
+
+## I Have a Question
+
+Before you ask a question, it is best to search for existing [Issues](https://github.com/department-of-veterans-affairs/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue.
+
+If you then still feel the need to ask a question and need clarification, we recommend the following:
+
+- Open an [Issue](https://github.com/department-of-veterans-affairs/breakers/issues/new).
+- Provide as much context as you can about what you're running into.
+- Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
+
+We will then take care of the issue as soon as possible.
+
+## I Want To Contribute
+
+> ### Legal Notice <!-- omit in toc -->
+> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
+
+## Reporting Bugs
+
+<!-- omit in toc -->
+### Before Submitting a Bug Report
+
+A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
+
+- Make sure that you are using the latest version.
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the documentation. If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/department-of-veterans-affairs/breakers/issues).
+- Collect information about the bug:
+  - Stack trace (Traceback)
+  - OS, Platform and Version (Windows, Linux, macOS, x86, ARM)
+  - Version of the interpreter, compiler, SDK, runtime environment, package manager, depending on what seems relevant.
+  - Possibly your input and the output
+- Can you reliably reproduce the issue? And can you also reproduce it with older versions?
+
+<!-- omit in toc -->
+### How Do I Submit a Good Bug Report?
+
+We use GitHub issues to track bugs and errors. If you run into an issue with the project:
+
+- Open an [Issue](https://github.com/department-of-veterans-affairs/breakers/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Explain the behavior you would expect and the actual behavior.
+- Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
+- Provide the information you collected in the previous section.
+
+Once it's filed:
+
+- The project team will label the issue accordingly.
+- A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs with the `needs-repro` tag will not be addressed until they are reproduced.
+- If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`), and the issue will be left to be implemented by someone.
+
+## Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for breakers, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
+
+<!-- omit in toc -->
+### Before Submitting an Enhancement
+
+- Make sure that you are using the latest version.
+- Read the documentation carefully and find out if the functionality is already covered, maybe by an individual configuration.
+- Perform a [search](https://github.com/department-of-veterans-affairs/breakers/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature or to develop the feature yourself and contribute it to the project.
+
+<!-- omit in toc -->
+### How Do I Submit a Good Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/department-of-veterans-affairs/breakers/issues).
+
+- Use a **clear and descriptive title** for the issue to identify the suggestion.
+- Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
+- **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
+- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to.
+- **Explain why this enhancement would be useful** to most breakers users.

--- a/breakers.gemspec
+++ b/breakers.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', ['>= 0.7.4', '< 0.10']
+  spec.add_dependency 'faraday', ['>= 0.7.4', '< 0.18']
   spec.add_dependency 'multi_json', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.0'

--- a/breakers.gemspec
+++ b/breakers.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', ['>= 0.7.4', '< 0.18']
+  spec.add_dependency 'faraday', ['>= 0.7.4', '< 2.0']
   spec.add_dependency 'multi_json', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.0'

--- a/breakers.gemspec
+++ b/breakers.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'breakers'
-  spec.version       = '1.0.1'
+  spec.version       = '1.0.2'
   spec.authors       = ['Aubrey Holland']
   spec.email         = ['aubrey@adhocteam.us']
 

--- a/lib/breakers/outage.rb
+++ b/lib/breakers/outage.rb
@@ -132,9 +132,9 @@ module Breakers
     end
 
     def replace_body(body:)
-      Breakers.client.redis_connection.multi do
-        Breakers.client.redis_connection.zrem(key, MultiJson.dump(@body))
-        Breakers.client.redis_connection.zadd(key, start_time.to_i, MultiJson.dump(body))
+      Breakers.client.redis_connection.multi do |pipeline|
+        pipeline.zrem(key, MultiJson.dump(@body))
+        pipeline.zadd(key, start_time.to_i, MultiJson.dump(body))
       end
       @body = body
     end

--- a/lib/breakers/uptime_middleware.rb
+++ b/lib/breakers/uptime_middleware.rb
@@ -54,7 +54,7 @@ module Breakers
     def handle_request(service:, request_env:, current_outage: nil)
       start_time = Time.now
       return @app.call(request_env).on_complete do |response_env|
-        response_env[:duration] = Time.now - start_time
+        response_env[:duration] = (Time.now - start_time) * 1000
         if response_env.status >= 500
           handle_error(
             service: service,

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.6.0'.freeze
 end

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.2.4'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end


### PR DESCRIPTION
This merges the 2019-2022 upstream changes of this `breakers` gem back into our custom version.

In particular this PR merges in a `pipeline` change. This uses the recommended "pipeline" block variable for the redis `multi` method, which is better than using the global redis variable.

When using redis 4.x, the previous version of `breakers` was emitting this deprecation warning:

> Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

So upgrading to this new version should eliminate that warning and clear up logs.

The only other change of note is that its statsd `duration` measure changes from seconds to milliseconds, but I do not believe Vox Media is using that data anywhere.